### PR TITLE
typo + explicit on container images

### DIFF
--- a/guide/index.md
+++ b/guide/index.md
@@ -1,8 +1,8 @@
 ## sigstore-the-easy-way
 
-Software signing just got easier. This guide is an easy way to geting started with software signing & securing software supply chains.
+Software signing just got easier. This guide is an easy way to getting started with software signing & securing software supply chains.
 
-Sigstore is one of the companies in the community that's actively working towards resolving supply chain security issues. The internal working of sigstore components is quite complex, considering the level of protection it provides. In the following sections, we get started with sigstore in the easiest way(s) possible.
+Sigstore is one of the companies in the community that's actively working towards resolving supply chain security issues. The internal working of sigstore components is quite complex, considering the level of protection it provides. In the following sections, we get started with sigstore in the easiest way(s) possible on container images.
 
 As we are trying to mitigate software supply chain security hacks, we often have to leverage other open-source tools to gather more information & secure the services. So, if you encounter non-sigstore toolings in the guide & don't get surprised.
 


### PR DESCRIPTION
extension of sigstore usage for other type of components is a work in progress...

that's a good reason to start "the easy way" with first target of sigstore: containers

but making explicit that there are extensions envisioned for other ecosystems would be nice: I don't know yet how to make it while staying simple, we'll see later